### PR TITLE
Add secure API key handling and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and set your Gemini API key
+GEMINI_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Python
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+venv/
+
+# IDE
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # codex_test
 # AI Agent Development with Google Gemini
 
-このリポジトリは，Google Gemini を利用した AI エージェントの開発用です．  
+このリポジトリは，Google Gemini を利用した AI エージェントの開発用です．
 まず仮想環境を構築し，段階的に機能を追加していきます．
 
 ---
@@ -10,3 +10,17 @@
 
 ### 1. 仮想環境の作成
 Python 3.10 以降を推奨します．
+
+### 2. API キーの設定
+1. `.env.example` を `.env` にコピーし，`GEMINI_API_KEY` を設定します．
+2. `.env` は `.gitignore` によりリポジトリにコミットされません．
+
+```bash
+cp .env.example .env
+```
+
+### 3. テストの実行
+
+```bash
+pytest
+```

--- a/src/agent.py
+++ b/src/agent.py
@@ -1,0 +1,24 @@
+"""Simple entry point demonstrating API key usage."""
+
+from __future__ import annotations
+
+from .config import get_api_key
+
+
+def create_client() -> dict:
+    """Create a mock client using the Gemini API key.
+
+    In a real implementation, this would initialize the Google Gemini client.
+    """
+    api_key = get_api_key()
+    return {"api_key": api_key}
+
+
+def main() -> None:
+    client = create_client()
+    # To avoid leaking the full key, show only partial information
+    print(f"Client initialized with key prefix: {client['api_key'][:4]}***")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,19 @@
+"""Configuration utilities for accessing environment variables."""
+
+from __future__ import annotations
+
+import os
+
+ENV_API_KEY = "GEMINI_API_KEY"
+
+
+def get_api_key() -> str:
+    """Return the Gemini API key from the environment.
+
+    Raises:
+        RuntimeError: If the API key is not set.
+    """
+    api_key = os.environ.get(ENV_API_KEY)
+    if not api_key:
+        raise RuntimeError(f"{ENV_API_KEY} is not set")
+    return api_key

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,23 @@
+"""Tests for config utility."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+# Ensure src package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import src.config as config
+
+
+def test_get_api_key_returns_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(config.ENV_API_KEY, "secret")
+    assert config.get_api_key() == "secret"
+
+
+def test_get_api_key_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(config.ENV_API_KEY, raising=False)
+    with pytest.raises(RuntimeError):
+        config.get_api_key()


### PR DESCRIPTION
## Summary
- Ignore local environment files and add example template for API keys
- Provide configuration utilities and agent entry point that read API key from environment
- Add tests validating API key retrieval logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a82e4ca37c83289ecd92a92f3f5ff3